### PR TITLE
Add simple middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+ 
+export function middleware(request: NextRequest) {
+  console.log("Edge middleware invoked");
+  return NextResponse.rewrite(new URL('/test/cached', request.url));
+}
+ 
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: '/test/cached-with-edge',
+};


### PR DESCRIPTION
Only when calling `/test/cached-with-edge`, the middleware is invoked to rewrite to `/test/cached`, thus allowing to test middleware performance for a cached page.